### PR TITLE
160901468 implement user CUD operations and admin operations

### DIFF
--- a/src/app/actions/requestActions.js
+++ b/src/app/actions/requestActions.js
@@ -79,7 +79,213 @@ const getSingleRequest = requestData => async (dispatch, getState) => {
   }
 };
 
+const createRequest = requestData => async (dispatch, getState) => {
+  const state = getState();
+  const { token } = state.auth;
+  const baseUrl = 'https://maintain-r.herokuapp.com/api/v1/users/requests';
+  dispatch({ type: types.LOADING });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(requestData),
+    });
+    const data = await response.json();
+    switch (data.statusCode) {
+      case 201:
+        dispatch({ type: types.CREATE_REQUEST, payload: data });
+        dispatch({ type: types.COMPLETE });
+        toastr.success(data.message);
+        break;
+      default:
+        dispatch({ type: types.PROCESS_ERROR });
+        dispatch({ type: types.COMPLETE });
+        toastr.error(data.message);
+        break;
+    }
+  } catch (error) {
+    dispatch({ type: types.NETWORK_ERROR });
+    dispatch({ type: types.COMPLETE });
+    toastr.error(error);
+  }
+};
+
+const deleteRequest = requestId => async (dispatch, getState) => {
+  const state = getState();
+  const { token } = state.auth;
+  const baseUrl = `https://maintain-r.herokuapp.com/api/v1/users/requests/${requestId}`;
+  dispatch({ type: types.LOADING });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'DELETE',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    switch (data.statusCode) {
+      case 200:
+        dispatch({ type: types.DELETE_REQUEST });
+        dispatch({ type: types.COMPLETE });
+        toastr.success(data.message);
+        break;
+      default:
+        dispatch({ type: types.PROCESS_ERROR });
+        dispatch({ type: types.COMPLETE });
+        toastr.error(data.message);
+        break;
+    }
+  } catch (error) {
+    dispatch({ type: types.NETWORK_ERROR });
+    dispatch({ type: types.COMPLETE });
+    toastr.error(error);
+  }
+};
+
+const updateRequest = (requestData, requestId) => async (dispatch, getState) => {
+  const state = getState();
+  const { token } = state.auth;
+  const baseUrl = `https://maintain-r.herokuapp.com/api/v1/users/requests/${requestId}`;
+  dispatch({ type: types.LOADING });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(requestData),
+    });
+    const data = await response.json();
+    switch (data.statusCode) {
+      case 200:
+        dispatch({ type: types.UPDATE_REQUEST, payload: data });
+        dispatch({ type: types.COMPLETE });
+        toastr.success(data.message);
+        break;
+      default:
+        dispatch({ type: types.PROCESS_ERROR });
+        dispatch({ type: types.COMPLETE });
+        toastr.error(data.message);
+        break;
+    }
+  } catch (error) {
+    dispatch({ type: types.NETWORK_ERROR });
+    dispatch({ type: types.COMPLETE });
+    toastr.error(error);
+  }
+};
+
+const approveRequest = requestId => async (dispatch, getState) => {
+  const state = getState();
+  const { token } = state.auth;
+  const baseUrl = `https://maintain-r.herokuapp.com/api/v1/requests/${requestId}/approve`;
+  dispatch({ type: types.LOADING });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    switch (data.statusCode) {
+      case 200:
+        dispatch({ type: types.APPROVE_REQUEST, payload: data });
+        dispatch({ type: types.COMPLETE });
+        toastr.success(data.message);
+        break;
+      default:
+        dispatch({ type: types.PROCESS_ERROR });
+        dispatch({ type: types.COMPLETE });
+        toastr.error(data.message);
+        break;
+    }
+  } catch (error) {
+    dispatch({ type: types.NETWORK_ERROR });
+    dispatch({ type: types.COMPLETE });
+    toastr.error(error);
+  }
+};
+
+const disapproveRequest = requestId => async (dispatch, getState) => {
+  const state = getState();
+  const { token } = state.auth;
+  const baseUrl = `https://maintain-r.herokuapp.com/api/v1/requests/${requestId}/disapprove`;
+  dispatch({ type: types.LOADING });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    switch (data.statusCode) {
+      case 200:
+        dispatch({ type: types.DISAPPROVE_REQUEST, payload: data });
+        dispatch({ type: types.COMPLETE });
+        toastr.success(data.message);
+        break;
+      default:
+        dispatch({ type: types.PROCESS_ERROR });
+        dispatch({ type: types.COMPLETE });
+        toastr.error(data.message);
+        break;
+    }
+  } catch (error) {
+    dispatch({ type: types.NETWORK_ERROR });
+    dispatch({ type: types.COMPLETE });
+    toastr.error(error);
+  }
+};
+
+const resolveRequest = requestId => async (dispatch, getState) => {
+  const state = getState();
+  const { token } = state.auth;
+  const baseUrl = `https://maintain-r.herokuapp.com/api/v1/requests/${requestId}/resolve`;
+  dispatch({ type: types.LOADING });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    switch (data.statusCode) {
+      case 200:
+        dispatch({ type: types.RESOLVE_REQUEST, payload: data });
+        dispatch({ type: types.COMPLETE });
+        toastr.success(data.message);
+        break;
+      default:
+        dispatch({ type: types.PROCESS_ERROR });
+        dispatch({ type: types.COMPLETE });
+        toastr.error(data.message);
+        break;
+    }
+  } catch (error) {
+    dispatch({ type: types.NETWORK_ERROR });
+    dispatch({ type: types.COMPLETE });
+    toastr.error(error);
+  }
+};
+
 export default {
   getAllRequests,
   getSingleRequest,
+  createRequest,
+  deleteRequest,
+  updateRequest,
+  approveRequest,
+  disapproveRequest,
+  resolveRequest,
 };

--- a/src/app/assets/css/home.css
+++ b/src/app/assets/css/home.css
@@ -24,10 +24,15 @@
   right: 50px;
 }
 
-form{
+form  {
 	padding: 10px;
 	padding-top: 50px;
+	width: 100%;
 	border: 1px solid rgba(220, 220, 220, 0.5);
+}
+
+.auth-form > * {
+	width: 100% !important;
 }
 
 form .output {

--- a/src/app/assets/css/new.css
+++ b/src/app/assets/css/new.css
@@ -1,0 +1,83 @@
+@import url('request.css');
+
+.form {
+  display: grid;
+  align-content: center;
+}
+
+.form > *{
+  margin: auto;
+  width: 100%;
+}
+
+.request-form .close-btn {
+	position: absolute;
+  top: 30px;
+  right: 30px;
+}
+
+.request-form textarea {
+	resize: none;
+	height: 100px;
+	background-color: rgba(0,0,0,0);
+	color: #fff;
+	caret-color: rgba(220, 220, 220, 0.5);
+	font-size: 1.2em;
+	border: none;
+	text-decoration: none;
+	border-bottom: 2px solid rgba(220, 220, 220, 0.5);
+}
+
+.request-form .transparent-selector, .request-form input {
+	background-color: rgba(0,0,0,0);
+	color: #FFF;
+	font-size: 1.2em;
+	text-decoration: none;
+}
+
+#new-request-btn {
+  margin-top: 15px;
+}
+
+form > * {
+  height: 35px;
+  font-size: 1em;
+}
+
+.body form input,
+.body form select,
+.body form textarea{
+	height: 35px;
+	background-color: rgba(0,0,0,0);
+	border: none;
+	text-decoration: none;
+	border-bottom: 2px solid rgba(220, 220, 220, 0.5);
+	caret-color: rgba(220, 220, 220, 0.5);
+	color: #F2994A;
+	font-size: 1.2em;
+}
+
+.body form textarea{
+	font-family: 'Rubik', sans-serif;
+}
+
+.body form input:focus,
+.body form select:focus,
+.body form textarea:focus{
+	outline: none;
+}
+
+.body form label{
+	display: block;
+	color: rgba(220, 220, 220, 1);
+	font-size: 1.2em;
+	margin-bottom: 10px;
+}
+
+.body form input[type="submit"],
+.body form input[type="button"]{
+	border: none;
+	cursor: pointer;
+	width: auto;
+	padding: 0px;
+}

--- a/src/app/components/InputComponent.js
+++ b/src/app/components/InputComponent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Input = ({
-  type, name, value, handleChange, label, id, isRequired, className,
+  type, name, value, handleChange, label, id, isRequired, className, handleClick,
 }) => (
   <React.Fragment>
     <label htmlFor={name}>{label}</label>
@@ -14,6 +14,7 @@ const Input = ({
       value={value}
       onChange={handleChange}
       required={isRequired}
+      onClick={handleClick}
     />
   </React.Fragment>
 );
@@ -25,17 +26,20 @@ Input.defaultProps = {
   label: undefined,
   handleChange: undefined,
   name: undefined,
+  handleClick: undefined,
+  value: undefined,
 };
 
 Input.propTypes = {
   type: PropTypes.string.isRequired,
   name: PropTypes.string,
-  value: PropTypes.node.isRequired,
+  value: PropTypes.node,
   handleChange: PropTypes.func,
   label: PropTypes.string,
   id: PropTypes.string,
   isRequired: PropTypes.string,
   className: PropTypes.string,
+  handleClick: PropTypes.func,
 };
 
 export default Input;

--- a/src/app/components/RequestCardComponent.js
+++ b/src/app/components/RequestCardComponent.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Input from './InputComponent';
 
-const displayButtons = (requestStatus, userRole, requestId) => {
+const displayButtons = (requestStatus, userRole, requestActions, showModal) => {
   if (userRole === 'admin') {
     switch (requestStatus) {
       case 'in-review':
@@ -12,7 +12,7 @@ const displayButtons = (requestStatus, userRole, requestId) => {
             <br /><br />
             <Input
               type="button"
-              onclick="approveRequest()"
+              handleClick={requestActions.approveRequest}
               className="button left green-bg white"
               id="approve-btn"
               value="Approve"
@@ -20,7 +20,7 @@ const displayButtons = (requestStatus, userRole, requestId) => {
             <br />
             <Input
               type="button"
-              onclick="disapproveRequest()"
+              handleClick={requestActions.disapproveRequest}
               className="button left green-bg white"
               id="disapprove-btn"
               value="Disapprove"
@@ -33,7 +33,7 @@ const displayButtons = (requestStatus, userRole, requestId) => {
           <React.Fragment>
             <Input
               type="button"
-              onclick="resolveRequest()"
+              handleClick={requestActions.resolveRequest}
               className="button left green-bg white"
               id="resolve-btn"
               value="Resolve"
@@ -62,21 +62,21 @@ const displayButtons = (requestStatus, userRole, requestId) => {
         return (
           <React.Fragment>
             <br /><br />
-            <Link to={`/request/${requestId}/edit`}>
-              <Input
-                type="button"
-                className="button left green-bg white"
-                id="edit-btn"
-                value="      Edit      "
-              />
-            </Link>
+            <Input
+              type="button"
+              className="button left green-bg white"
+              name="edit-request"
+              handleClick={showModal}
+              id="edit-btn"
+              value="       Edit       "
+            />
             <br />
             <Input
               type="button"
-              onclick="deleteRequest()"
+              handleClick={requestActions.deleteRequest}
               className="button left green-bg white"
               id="delete-btn"
-              value="   Delete   "
+              value="    Delete    "
             />
             <br /><br />
           </React.Fragment>
@@ -87,7 +87,9 @@ const displayButtons = (requestStatus, userRole, requestId) => {
   }
 };
 
-const RequestCard = ({ request, role }) => (
+const RequestCard = ({
+  request, role, requestActions, showModal,
+}) => (
   <div className="card white">
     <div className="row">
       <h2 id="title" className="left orange">{request.item}, {request.type}</h2>
@@ -107,7 +109,7 @@ const RequestCard = ({ request, role }) => (
     <br />
     <br />
     <div className="row center" id="request-btns">
-      {displayButtons(request.status, role, request.id)}
+      {displayButtons(request.status, role, requestActions, showModal)}
     </div>
   </div>
 );
@@ -116,6 +118,8 @@ const RequestCard = ({ request, role }) => (
 RequestCard.propTypes = {
   request: PropTypes.shape({}).isRequired,
   role: PropTypes.string.isRequired,
+  requestActions: PropTypes.shape({}).isRequired,
+  showModal: PropTypes.func.isRequired,
 };
 
 export default RequestCard;

--- a/src/app/components/RequestForm.js
+++ b/src/app/components/RequestForm.js
@@ -45,7 +45,7 @@ class RequestForm extends Component {
   render() {
     const { handleClose, initialValues } = this.props;
     const {
-      type, item, model, detail, id, isNew,
+      type, item, model, detail, id,
     } = this.state;
     return (
       <React.Fragment>
@@ -56,7 +56,7 @@ class RequestForm extends Component {
             name="id"
             value={id}
           />
-          <label id="title" className="left orange center">{ isNew ? 'Create a new request' : 'Update request' }</label>
+          <label id="title" className="left orange center">{ initialValues === undefined ? 'Create a new request' : 'Update request' }</label>
           <select name="type" id="type" required="required" className="transparent-selector" value={type} onChange={this.handleChange}>
             <option value="" disabled>Select request type</option>
             <option value="maintenance">Maintenance</option>
@@ -103,13 +103,10 @@ class RequestForm extends Component {
 }
 
 RequestForm.defaultProps = {
-  history: undefined,
   initialValues: undefined,
 };
 
 RequestForm.propTypes = {
-  request: PropTypes.shape({}).isRequired,
-  history: PropTypes.shape({}),
   createRequest: PropTypes.func.isRequired,
   updateRequest: PropTypes.func.isRequired,
   handleClose: PropTypes.func.isRequired,
@@ -118,7 +115,6 @@ RequestForm.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  request: state.requests.request,
   history: ownProps.history,
   match: ownProps.match,
 });

--- a/src/app/components/RequestForm.js
+++ b/src/app/components/RequestForm.js
@@ -1,0 +1,132 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import Input from './InputComponent';
+import '../assets/css/new.css';
+import requestActions from '../actions/requestActions';
+
+class RequestForm extends Component {
+  constructor(props) {
+    super(props);
+    const { initialValues } = this.props;
+    this.state = {
+      type: initialValues !== undefined ? initialValues.type : '',
+      item: initialValues !== undefined ? initialValues.item : '',
+      model: initialValues !== undefined ? initialValues.model : '',
+      detail: initialValues !== undefined ? initialValues.detail : '',
+      id: initialValues !== undefined ? initialValues.id : undefined,
+    };
+  }
+
+  handleChange = (event) => {
+    this.setState({
+      [event.target.name]: event.target.value,
+    });
+  }
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    const {
+      type, item, model, detail, id,
+    } = this.state;
+    const requestData = {
+      type, item, detail, model,
+    };
+    const { createRequest, updateRequest, getAllRequests } = this.props;
+    if (id === undefined) {
+      createRequest(requestData);
+    } else {
+      updateRequest(requestData, id);
+    }
+    getAllRequests();
+  }
+
+  render() {
+    const { handleClose, initialValues } = this.props;
+    const {
+      type, item, model, detail, id, isNew,
+    } = this.state;
+    return (
+      <React.Fragment>
+        <form className="form request-form" id="new-request-form" onSubmit={this.handleSubmit}>
+          <span id="sign-up-form-close-btn" className="close-btn grey right" onClick={handleClose}>x</span>
+          <Input
+            type="hidden"
+            name="id"
+            value={id}
+          />
+          <label id="title" className="left orange center">{ isNew ? 'Create a new request' : 'Update request' }</label>
+          <select name="type" id="type" required="required" className="transparent-selector" value={type} onChange={this.handleChange}>
+            <option value="" disabled>Select request type</option>
+            <option value="maintenance">Maintenance</option>
+            <option value="repair">Repair</option>
+          </select>
+          <br />
+          <Input
+            type="text"
+            name="item"
+            id="item"
+            value={item}
+            isRequired="required"
+            label="Item:"
+            handleChange={this.handleChange}
+          />
+          <br />
+          <Input
+            type="text"
+            id="model"
+            name="model"
+            value={model}
+            isRequired="required"
+            label="Model:"
+            handleChange={this.handleChange}
+          />
+          <br />
+          <label>
+            <span>Description:</span>
+          </label>
+          <textarea
+            type="text"
+            name="detail"
+            cols="40"
+            id="detail"
+            required="required"
+            value={detail}
+            onChange={this.handleChange}
+          />
+          <Input type="submit" id="new-request-btn" value="Submit" className="white auth-submit-btn" />
+        </form>
+      </React.Fragment>
+    );
+  }
+}
+
+RequestForm.defaultProps = {
+  history: undefined,
+  initialValues: undefined,
+};
+
+RequestForm.propTypes = {
+  request: PropTypes.shape({}).isRequired,
+  history: PropTypes.shape({}),
+  createRequest: PropTypes.func.isRequired,
+  updateRequest: PropTypes.func.isRequired,
+  handleClose: PropTypes.func.isRequired,
+  initialValues: PropTypes.shape({}),
+  getAllRequests: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  request: state.requests.request,
+  history: ownProps.history,
+  match: ownProps.match,
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  getAllRequests: () => (requestActions.getAllRequests()),
+  createRequest: requestData => (requestActions.createRequest(requestData)),
+  updateRequest: (requestData, requestId) => (requestActions.updateRequest(requestData, requestId)),
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(RequestForm);

--- a/src/app/containers/DashboardContainer.js
+++ b/src/app/containers/DashboardContainer.js
@@ -20,18 +20,6 @@ class Dashboard extends Component {
     };
   }
 
-  showModal = (event) => {
-    this.setState({
-      show: true,
-    });
-  };
-
-  hideModal = () => {
-    this.setState({
-      show: false,
-    });
-  };
-
   componentDidMount = () => {
     const { getRequests, history, user } = this.props;
     if (user.role !== 'admin') {
@@ -43,8 +31,20 @@ class Dashboard extends Component {
     getRequests();
   }
 
+  showModal = () => {
+    this.setState({
+      show: true,
+    });
+  };
+
+  hideModal = () => {
+    this.setState({
+      show: false,
+    });
+  };
+
   render() {
-    const { show, modalContent } = this.state;
+    const { show } = this.state;
     const {
       loading, requests, user, message,
     } = this.props;

--- a/src/app/containers/DashboardContainer.js
+++ b/src/app/containers/DashboardContainer.js
@@ -8,21 +8,32 @@ import Loader from '../components/LoaderComponent';
 import RequestTable from '../components/RequestTableComponent';
 import spannerScrewdriver from '../assets/img/spanner-screwdriver.svg';
 import Input from '../components/InputComponent';
+import Modal from '../components/ModalComponent';
 import '../assets/css/dashboard.css';
+import RequestForm from '../components/RequestForm';
 
 class Dashboard extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      show: false,
+    };
   }
 
+  showModal = (event) => {
+    this.setState({
+      show: true,
+    });
+  };
+
+  hideModal = () => {
+    this.setState({
+      show: false,
+    });
+  };
+
   componentDidMount = () => {
-    const {
-      authenticated, getRequests, history, user,
-    } = this.props;
-    if (!authenticated && user === undefined) {
-      history.push('/');
-    }
+    const { getRequests, history, user } = this.props;
     if (user.role !== 'admin') {
       history.push('/dashboard');
     }
@@ -33,11 +44,15 @@ class Dashboard extends Component {
   }
 
   render() {
+    const { show, modalContent } = this.state;
     const {
       loading, requests, user, message,
     } = this.props;
     return (
       <React.Fragment>
+        <Modal show={show} handleClose={this.hideModal}>
+          <RequestForm handleClose={this.hideModal} />
+        </Modal>
         <Navbar profileIconVisibility="" />
         <div className="body" style={{ backgroundImage: `url(${spannerScrewdriver})` }}>
           <div className="wrapper">
@@ -60,9 +75,14 @@ class Dashboard extends Component {
               </span>
               { user.role !== 'admin' ? (
                 <span>
-                  <a href="/new">
-                    <Input id="new-request-btn" className="button" type="button" value="New Request" />
-                  </a>
+                  <Input
+                    id="new-request-btn"
+                    className="button"
+                    type="button"
+                    name="new-request"
+                    value="New Request"
+                    handleClick={this.showModal}
+                  />
                 </span>)
                 : false }
             </div>

--- a/src/app/containers/HomepageContainer.js
+++ b/src/app/containers/HomepageContainer.js
@@ -53,7 +53,7 @@ class Homepage extends Component {
         <Modal show={show} handleClose={this.hideModal}>
           { modalContent === 'sign-in' ? <LoginForm handleClose={this.hideModal} history={history} /> : <SignupForm handleClose={this.hideModal} /> }
         </Modal>
-        <Navbar profileIconVisibility="hidden" />
+        <Navbar />
         <div className="">
           <div className="body" style={{ backgroundImage: `url(${backgroundImage})` }}>
             <div className="article left">

--- a/src/app/containers/LoginContainer.js
+++ b/src/app/containers/LoginContainer.js
@@ -40,7 +40,7 @@ class LoginForm extends Component {
     const { handleClose, loading } = this.props;
     return (
       <React.Fragment>
-        <div id="sign-in-form" className="form">
+        <div id="sign-in-form" className="auth-form">
           <form id="login-form" onSubmit={this.handleSubmit}>
             <span id="sign-up-form-close-btn" className="close-btn grey right" onClick={handleClose}>x</span>
             <p className="output white" />

--- a/src/app/containers/NotFoundContainer.js
+++ b/src/app/containers/NotFoundContainer.js
@@ -6,7 +6,7 @@ const NotFound = () => (
   <React.Fragment>
     <div className="wrapper">
       <Navbar />
-      <div className="body" style={{ backgroundImage: "url('../assets/img/gears.svg');" }}>
+      <div className="body" style={{ backgroundImage: "url('../assets/img/gears.svg')" }}>
         <div className="wrapper white">
           <h1 className="center" id="four-o-four-message">
             <span role="img" aria-label="sad face">😢</span><br />Nothing exists here.

--- a/src/app/containers/SignupContainer.js
+++ b/src/app/containers/SignupContainer.js
@@ -46,7 +46,7 @@ class SignupForm extends Component {
     const { handleClose, loading } = this.props;
     return (
       <React.Fragment>
-        <div id="sign-up-form" className="form">
+        <div id="sign-up-form" className="auth-form">
           <form id="signup-form" onSubmit={this.handleSubmit}>
             <span id="sign-up-form-close-btn" className="close-btn grey right" onClick={handleClose}>x</span>
             <p className="output white" />

--- a/src/app/containers/ViewRequestContainer.js
+++ b/src/app/containers/ViewRequestContainer.js
@@ -8,11 +8,15 @@ import '../assets/css/request.css';
 import cloudGearSpanner from '../assets/img/cloud-gear-spanner.svg';
 import RequestCard from '../components/RequestCardComponent';
 import Loader from '../components/LoaderComponent';
+import Modal from '../components/ModalComponent';
+import RequestForm from '../components/RequestForm';
 
 class ViewRequest extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      show: false,
+    };
   }
 
   componentDidMount = () => {
@@ -21,15 +25,69 @@ class ViewRequest extends Component {
     getRequest(requestId);
   }
 
+  showModal = () => {
+    this.setState({
+      show: true,
+    });
+  };
+
+  hideModal = () => {
+    this.setState({
+      show: false,
+    });
+  };
+
+  deleteRequest = () => {
+    const { match, deleteRequest, history } = this.props;
+    const { requestId } = match.params;
+    deleteRequest(requestId);
+  }
+
+  approveRequest = () => {
+    const { match, approveRequest } = this.props;
+    const { requestId } = match.params;
+    approveRequest(requestId);
+  }
+
+  disapproveRequest = () => {
+    const { match, disapproveRequest } = this.props;
+    const { requestId } = match.params;
+    disapproveRequest(requestId);
+  }
+
+  resolveRequest = () => {
+    const { match, resolveRequest } = this.props;
+    const { requestId } = match.params;
+    resolveRequest(requestId);
+  }
+
   render() {
-    const { request, loading, user } = this.props;
+    const {
+      request, loading, user,
+    } = this.props;
+    const { show } = this.state;
     return (
       <React.Fragment>
+        <Modal show={show} handleClose={this.hideModal}>
+          <RequestForm handleClose={this.hideModal} initialValues={request} />
+        </Modal>
         <Navbar />
         <div className="body" style={{ backgroundImage: `url(${cloudGearSpanner})` }}>
           <p className="output white center" id="output" />
           <div className="wrapper" id="wrapper">
-            { typeof request !== 'array' ? <RequestCard request={request} role={user.role} /> : <p className="white">Request does not exist</p> }
+            { typeof request !== 'array' ? (
+              <RequestCard
+                request={request}
+                role={user.role}
+                requestActions={{
+                  deleteRequest: this.deleteRequest,
+                  approveRequest: this.approveRequest,
+                  disapproveRequest: this.disapproveRequest,
+                  resolveRequest: this.resolveRequest,
+                }}
+                showModal={this.showModal}
+              />)
+              : <p className="white">Request does not exist</p> }
           </div>
         </div>
         { loading ? <Loader /> : false }
@@ -44,6 +102,11 @@ ViewRequest.propTypes = {
   loading: PropTypes.bool.isRequired,
   user: PropTypes.shape({}).isRequired,
   match: PropTypes.shape({}).isRequired,
+  history: PropTypes.shape({}).isRequired,
+  deleteRequest: PropTypes.func.isRequired,
+  approveRequest: PropTypes.func.isRequired,
+  disapproveRequest: PropTypes.func.isRequired,
+  resolveRequest: PropTypes.func.isRequired,
 };
 
 const matchStateToProps = (state, ownProps) => ({
@@ -51,10 +114,15 @@ const matchStateToProps = (state, ownProps) => ({
   request: state.requests.request,
   match: ownProps.match,
   user: state.auth.user,
+  history: ownProps.history,
 });
 
 const matchDispatchToProps = dispatch => bindActionCreators({
   getRequest: requestData => (getAllRequests.getSingleRequest(requestData)),
+  deleteRequest: requestId => (getAllRequests.deleteRequest(requestId)),
+  approveRequest: requestId => (getAllRequests.approveRequest(requestId)),
+  disapproveRequest: requestId => (getAllRequests.disapproveRequest(requestId)),
+  resolveRequest: requestId => (getAllRequests.resolveRequest(requestId)),
 }, dispatch);
 
 export default connect(matchStateToProps, matchDispatchToProps)(ViewRequest);

--- a/src/app/containers/ViewRequestContainer.js
+++ b/src/app/containers/ViewRequestContainer.js
@@ -38,7 +38,7 @@ class ViewRequest extends Component {
   };
 
   deleteRequest = () => {
-    const { match, deleteRequest, history } = this.props;
+    const { match, deleteRequest } = this.props;
     const { requestId } = match.params;
     deleteRequest(requestId);
   }
@@ -102,7 +102,6 @@ ViewRequest.propTypes = {
   loading: PropTypes.bool.isRequired,
   user: PropTypes.shape({}).isRequired,
   match: PropTypes.shape({}).isRequired,
-  history: PropTypes.shape({}).isRequired,
   deleteRequest: PropTypes.func.isRequired,
   approveRequest: PropTypes.func.isRequired,
   disapproveRequest: PropTypes.func.isRequired,
@@ -114,7 +113,6 @@ const matchStateToProps = (state, ownProps) => ({
   request: state.requests.request,
   match: ownProps.match,
   user: state.auth.user,
-  history: ownProps.history,
 });
 
 const matchDispatchToProps = dispatch => bindActionCreators({

--- a/src/app/reducers/requestReducer.js
+++ b/src/app/reducers/requestReducer.js
@@ -21,6 +21,20 @@ const requestReducer = (state = initialState, action) => {
         request: action.payload.request,
         message: action.payload.message,
       };
+    case types.CREATE_REQUEST:
+    case types.UPDATE_REQUEST:
+    case types.APPROVE_REQUEST:
+    case types.DISAPPROVE_REQUEST:
+    case types.RESOLVE_REQUEST:
+      return {
+        ...state,
+        request: action.payload.result,
+        message: action.payload.message,
+      };
+    case types.DELETE_REQUEST:
+      return {
+        ...state,
+      };
     default:
       return state;
   }

--- a/src/app/store/store.js
+++ b/src/app/store/store.js
@@ -18,10 +18,10 @@ const store = createStore(
 );
 
 /**
- * update the state of the store in localStorage every second
+ * update the state of the store in localStorage every 100ms
  */
 store.subscribe(throttle(() => {
   saveState(store.getState());
-}, 2000));
+}, 100));
 
 export default store;


### PR DESCRIPTION
#### What does this PR do?
- implement user CUD operations on a request and enable admin to approcve, disapprove and resolve requests

#### Description of Task to be completed?
- user can create/update/delete a request
- admin can perform actions on request (approve, disapprove and resolve)

#### How should this be manually tested?
- visit https://maintenance-react-staging.herokuapp.com to sign in to your dashboard
- click the New Request button to create a request
- to edit a request, click the View button by the request in the table to view the request page, then click the Edit button to edit it.
- to delete a request, click the Delete button on the single request view page
- as an admin, you will see buttons to approve, disapprove or resolve a request depending on the request's status on the single request view page.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#160901468](https://www.pivotaltracker.com/story/show/160901468)
[#160901515](https://www.pivotaltracker.com/story/show/160901515)
[#160901571](https://www.pivotaltracker.com/story/show/160901571)
[#160901859](https://www.pivotaltracker.com/story/show/160901859)

#### Screenshots
<img width="1458" alt="screen shot 2018-10-05 at 2 18 47 am" src="https://user-images.githubusercontent.com/7345686/46511235-4aeaca80-c845-11e8-957a-2ee744493d8e.png">

#### Questions:
N/A

[Delivers #160901468 #160901515 #160901571 #160901859]