### PR TITLE
#161119158 fix state persisted after logout

### DIFF
--- a/src/app/actions/authActions.js
+++ b/src/app/actions/authActions.js
@@ -36,7 +36,9 @@ const authenticate = (userData, path) => async (dispatch) => {
   }
 };
 
+const logout = () => ({ type: types.LOGOUT });
+
 export default {
   authenticate,
-  logout: () => ({ type: types.LOGOUT }),
+  logout,
 };

--- a/src/app/reducers/authReducer.js
+++ b/src/app/reducers/authReducer.js
@@ -19,12 +19,8 @@ const authReducer = (state = initialState, action) => {
       };
     case types.LOGOUT:
       clearState();
-      return {
-        ...state,
-        user: undefined,
-        token: undefined,
-        authenticated: false,
-      };
+      window.location.replace('/');
+      break;
     default:
       return state;
   }

--- a/src/app/store/persistState.js
+++ b/src/app/store/persistState.js
@@ -9,7 +9,7 @@
  */
 export const saveState = (state) => {
   const serialisedState = JSON.stringify(state);
-  window.localStorage.setItem('maintenance-react', serialisedState);
+  localStorage.setItem('maintenance-react', serialisedState);
 };
 
 /**
@@ -17,7 +17,7 @@ export const saveState = (state) => {
  * @returns {Object} the state
  */
 export const loadState = () => {
-  const state = window.localStorage.getItem('maintenance-react');
+  const state = localStorage.getItem('maintenance-react');
   const parsedState = state !== null && state !== undefined ? JSON.parse(state) : undefined;
   return parsedState;
 };
@@ -26,5 +26,5 @@ export const loadState = () => {
  * @description Clears the persisted state from localStorage
  */
 export const clearState = () => {
-  window.localStorage.removeItem('maintenance-react');
+  localStorage.removeItem('maintenance-react');
 };

--- a/src/tests/reducers/authReducer.spec.js
+++ b/src/tests/reducers/authReducer.spec.js
@@ -60,13 +60,8 @@ describe('Auth Reducer Test', () => {
   test('LOGOUT', () => {
     const action = {
       type: 'LOGOUT',
-      payload: null,
     };
-    const expectedState = {
-      authenticated: false,
-      token: undefined,
-      user: undefined,
-    };
+    const expectedState = undefined;
     expect(authReducer(undefined, action)).toEqual(expectedState);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
fixes persisted user state on logout

#### Description of Task to be completed?
- change clearState implementation
- redirect to '/' after logout

#### How should this be manually tested?
- visit https://maintenance-react-staging.herokuapp.com and log in.
- log out and log in with another account

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#161119158](https://www.pivotaltracker.com/story/show/161119158)

#### Screenshots
N/A

#### Questions:
N/A

[Delivers #161119158]